### PR TITLE
Add tag collections and attach tags to items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "percentage",
  "rust_decimal",
  "rusty-money",
+ "smallvec",
  "testresult",
  "thiserror",
 ]
@@ -498,6 +499,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 percentage = "0.1.0"
 rust_decimal = "1.40.0"
 rusty-money = "0.5.0"
+smallvec = "1.15.1"
 testresult = "0.4.1"
 thiserror = "2.0.18"
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -2,26 +2,44 @@
 
 use rusty_money::{Money, iso};
 
-/// An unprocessed item
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Item<'a> {
+use crate::tags::{collection::TagCollection, string::StringTagCollection};
+
+/// An unprocessed item with a price and tags.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Item<'a, T: TagCollection = StringTagCollection> {
     price: Money<'a, iso::Currency>,
+    tags: T,
 }
 
-impl<'a> Item<'a> {
-    /// Creates a new item with the given price
+impl<'a, T: TagCollection> Item<'a, T> {
+    /// Creates a new item with the given price and empty tags.
     pub fn new(price: Money<'a, iso::Currency>) -> Self {
-        Self { price }
+        Self::with_tags(price, T::empty())
+    }
+
+    /// Creates a new item with the given price and tags.
+    pub fn with_tags(price: Money<'a, iso::Currency>, tags: T) -> Self {
+        Self { price, tags }
     }
 
     /// Returns the price of the item
     pub fn price(&self) -> &Money<'a, iso::Currency> {
         &self.price
     }
+
+    /// Returns the tags for the item.
+    pub fn tags(&self) -> &T {
+        &self.tags
+    }
+
+    /// Returns the tags for the item, mutably.
+    pub fn tags_mut(&mut self) -> &mut T {
+        &mut self.tags
+    }
 }
 
 /// Returns the cheapest item in a list of items
-pub fn cheapest_item<'a>(items: &'a [Item<'a>]) -> Option<&'a Item<'a>> {
+pub fn cheapest_item<'a, T: TagCollection>(items: &'a [Item<'a, T>]) -> Option<&'a Item<'a, T>> {
     items
         .iter()
         .min_by_key(|item| item.price().to_minor_units())
@@ -33,10 +51,26 @@ mod tests {
 
     #[test]
     fn test_cheapest_item() {
-        let item_1 = Item::new(Money::from_minor(100, iso::USD));
-        let item_2 = Item::new(Money::from_minor(200, iso::USD));
-        let items = [item_1, item_2];
+        let items: [Item<'_, StringTagCollection>; 2] = [
+            Item::with_tags(
+                Money::from_minor(100, iso::USD),
+                StringTagCollection::empty(),
+            ),
+            Item::new(Money::from_minor(200, iso::USD)),
+        ];
 
-        assert_eq!(cheapest_item(&items), Some(&item_1));
+        let cheapest = cheapest_item(&items).expect("expected cheapest item");
+        assert_eq!(cheapest.price(), &Money::from_minor(100, iso::USD));
+    }
+
+    #[test]
+    fn item_tag_accessors_work() {
+        let tags = StringTagCollection::from_strs(&["fresh"]);
+        let mut item = Item::with_tags(Money::from_minor(150, iso::USD), tags);
+
+        assert!(item.tags().contains("fresh"));
+
+        item.tags_mut().add("sale");
+        assert!(item.tags().contains("sale"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod basket;
 pub mod discounts;
 pub mod items;
 pub mod pricing;
+pub mod tags;

--- a/src/pricing.rs
+++ b/src/pricing.rs
@@ -3,7 +3,7 @@
 use rusty_money::{Money, MoneyError, iso};
 use thiserror::Error;
 
-use crate::items::Item;
+use crate::{items::Item, tags::collection::TagCollection};
 
 /// Errors that can occur while calculating total price.
 #[derive(Debug, Error, PartialEq)]
@@ -23,7 +23,9 @@ pub enum TotalPriceError {
 ///
 /// - [`TotalPriceError::NoItems`]: No items were provided, so currency could not be determined.
 /// - [`TotalPriceError::Money`]: Wrapped money arithmetic or currency mismatch error.
-pub fn total_price<'a>(items: &[Item<'a>]) -> Result<Money<'a, iso::Currency>, TotalPriceError> {
+pub fn total_price<'a, T: TagCollection>(
+    items: &[Item<'a, T>],
+) -> Result<Money<'a, iso::Currency>, TotalPriceError> {
     let first = items.first().ok_or(TotalPriceError::NoItems)?;
 
     let total = items.iter().try_fold(
@@ -38,11 +40,13 @@ pub fn total_price<'a>(items: &[Item<'a>]) -> Result<Money<'a, iso::Currency>, T
 mod tests {
     use testresult::TestResult;
 
+    use crate::tags::string::StringTagCollection;
+
     use super::*;
 
     #[test]
     fn test_total_price() -> TestResult {
-        let items = [
+        let items: [Item<'_, StringTagCollection>; 2] = [
             Item::new(Money::from_minor(100, iso::USD)),
             Item::new(Money::from_minor(200, iso::USD)),
         ];

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,0 +1,6 @@
+//! Tags
+//!
+//! Tags are used to match items and promotions/slots.
+
+pub mod collection;
+pub mod string;

--- a/src/tags/collection.rs
+++ b/src/tags/collection.rs
@@ -1,0 +1,48 @@
+//! Tag Collection
+//!
+//! A collection-based tagging system for efficient intersection operations.
+
+use std::{
+    fmt,
+    ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign},
+};
+
+/// Trait for tag collections that support intersection operations.
+pub trait TagCollection:
+    Clone
+    + fmt::Debug
+    + PartialEq
+    + BitAnd<Output = Self>
+    + BitOr<Output = Self>
+    + BitXor<Output = Self>
+    + BitAndAssign
+    + BitOrAssign
+    + BitXorAssign
+{
+    /// Check if this collection intersects with another collection.
+    /// Returns true if they have at least one tag in common.
+    fn intersects(&self, other: &Self) -> bool;
+
+    /// Get the intersection of this collection with another.
+    /// Returns a new collection containing only the common tags.
+    #[must_use]
+    fn intersection(&self, other: &Self) -> Self;
+
+    /// Check if this collection contains a specific tag.
+    fn contains(&self, tag: &str) -> bool;
+
+    /// Check if this collection is empty.
+    fn is_empty(&self) -> bool;
+
+    /// Get the number of tags in this collection.
+    fn len(&self) -> usize;
+
+    /// Create an empty collection.
+    fn empty() -> Self;
+
+    /// Add a tag to this collection.
+    fn add(&mut self, tag: &str);
+
+    /// Remove a tag from this collection.
+    fn remove(&mut self, tag: &str);
+}

--- a/src/tags/string.rs
+++ b/src/tags/string.rs
@@ -1,0 +1,520 @@
+//! String-based Tag Collection
+//!
+//! A `Vec<String>`-based implementation of [`TagCollection`] for simple or test operations.
+
+use std::{
+    cmp::Ordering,
+    ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign},
+    string::ToString,
+};
+
+use smallvec::SmallVec;
+
+use crate::tags::collection::TagCollection;
+
+/// A string-based tag collection using `SmallVec<[String; 5]>` for simple operations.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StringTagCollection {
+    tags: SmallVec<[String; 5]>,
+}
+
+impl StringTagCollection {
+    /// Create a new string tag collection from a vector of strings.
+    pub fn new(tags: SmallVec<[String; 5]>) -> Self {
+        let mut collection = Self { tags };
+
+        collection.tags.sort();
+        collection.tags.dedup();
+
+        collection
+    }
+
+    /// Create a new string tag collection from string slices.
+    pub fn from_strs(tags: &[&str]) -> Self {
+        Self::new(
+            tags.iter()
+                .map(ToString::to_string)
+                .collect::<SmallVec<[String; 5]>>(),
+        )
+    }
+}
+
+impl TagCollection for StringTagCollection {
+    fn empty() -> Self {
+        Self {
+            tags: SmallVec::with_capacity(0),
+        }
+    }
+
+    fn intersects(&self, other: &Self) -> bool {
+        // Use two pointers approach on sorted vectors for O(n + m) performance.
+        let mut left = self.tags.iter();
+        let mut right = other.tags.iter();
+        let mut left_tag = left.next();
+        let mut right_tag = right.next();
+
+        while let (Some(left_tag_ref), Some(right_tag_ref)) = (left_tag, right_tag) {
+            match left_tag_ref.cmp(right_tag_ref) {
+                Ordering::Equal => return true,
+                Ordering::Less => left_tag = left.next(),
+                Ordering::Greater => right_tag = right.next(),
+            }
+        }
+
+        false
+    }
+
+    fn intersection(&self, other: &Self) -> Self {
+        let mut result = SmallVec::new();
+        let mut left = self.tags.iter();
+        let mut right = other.tags.iter();
+        let mut left_tag = left.next();
+        let mut right_tag = right.next();
+
+        while let (Some(left_tag_ref), Some(right_tag_ref)) = (left_tag, right_tag) {
+            match left_tag_ref.cmp(right_tag_ref) {
+                Ordering::Equal => {
+                    result.push(left_tag_ref.clone());
+                    left_tag = left.next();
+                    right_tag = right.next();
+                }
+                Ordering::Less => left_tag = left.next(),
+                Ordering::Greater => right_tag = right.next(),
+            }
+        }
+
+        Self { tags: result }
+    }
+
+    fn contains(&self, tag: &str) -> bool {
+        self.tags.binary_search(&tag.to_string()).is_ok()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.tags.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.tags.len()
+    }
+
+    fn add(&mut self, tag: &str) {
+        let tag_string = tag.to_string();
+
+        if let Err(pos) = self.tags.binary_search(&tag_string) {
+            self.tags.insert(pos, tag_string);
+        }
+    }
+
+    fn remove(&mut self, tag: &str) {
+        let tag_string = tag.to_string();
+
+        if let Ok(pos) = self.tags.binary_search(&tag_string) {
+            self.tags.remove(pos);
+        }
+    }
+}
+
+impl BitAnd for StringTagCollection {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        self.intersection(&rhs)
+    }
+}
+
+impl BitOr for StringTagCollection {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        let capacity = self.tags.len().saturating_add(rhs.tags.len());
+        let mut result = SmallVec::with_capacity(capacity);
+        let mut left = self.tags.iter().peekable();
+        let mut right = rhs.tags.iter().peekable();
+
+        // Merge two sorted vectors (union).
+        while let (Some(left_tag), Some(right_tag)) = (left.peek(), right.peek()) {
+            match left_tag.cmp(right_tag) {
+                Ordering::Less => {
+                    if let Some(tag) = left.next() {
+                        result.push(tag.clone());
+                    }
+                }
+                Ordering::Greater => {
+                    if let Some(tag) = right.next() {
+                        result.push(tag.clone());
+                    }
+                }
+                Ordering::Equal => {
+                    if let Some(tag) = left.next() {
+                        result.push(tag.clone());
+                    }
+                    right.next();
+                }
+            }
+        }
+
+        result.extend(left.cloned());
+        result.extend(right.cloned());
+
+        Self { tags: result }
+    }
+}
+
+impl BitXor for StringTagCollection {
+    type Output = Self;
+
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        let mut result = SmallVec::new();
+        let mut left = self.tags.iter().peekable();
+        let mut right = rhs.tags.iter().peekable();
+
+        // Symmetric difference (elements in either but not both)
+        while let (Some(left_tag), Some(right_tag)) = (left.peek(), right.peek()) {
+            match left_tag.cmp(right_tag) {
+                Ordering::Less => {
+                    if let Some(tag) = left.next() {
+                        result.push(tag.clone());
+                    }
+                }
+                Ordering::Greater => {
+                    if let Some(tag) = right.next() {
+                        result.push(tag.clone());
+                    }
+                }
+                Ordering::Equal => {
+                    // Skip elements that are in both
+                    left.next();
+                    right.next();
+                }
+            }
+        }
+
+        result.extend(left.cloned());
+        result.extend(right.cloned());
+
+        Self { tags: result }
+    }
+}
+
+impl BitAndAssign for StringTagCollection {
+    fn bitand_assign(&mut self, rhs: Self) {
+        let mut result = SmallVec::new();
+        let mut left = std::mem::take(&mut self.tags).into_iter().peekable();
+        let mut right = rhs.tags.into_iter().peekable();
+
+        while let (Some(left_tag), Some(right_tag)) = (left.peek(), right.peek()) {
+            match left_tag.cmp(right_tag) {
+                Ordering::Equal => {
+                    if let Some(tag) = left.next() {
+                        result.push(tag);
+                    }
+                    right.next();
+                }
+                Ordering::Less => {
+                    left.next();
+                }
+                Ordering::Greater => {
+                    right.next();
+                }
+            }
+        }
+
+        self.tags = result;
+    }
+}
+
+impl BitOrAssign for StringTagCollection {
+    fn bitor_assign(&mut self, rhs: Self) {
+        // For union, we can use the fact that both vectors are sorted.
+        let left_len = self.tags.len();
+        let right_len = rhs.tags.len();
+        let capacity = left_len.saturating_add(right_len);
+        let mut result = SmallVec::with_capacity(capacity);
+        let mut left = std::mem::take(&mut self.tags).into_iter().peekable();
+        let mut right = rhs.tags.into_iter().peekable();
+
+        while let (Some(left_tag), Some(right_tag)) = (left.peek(), right.peek()) {
+            match left_tag.cmp(right_tag) {
+                Ordering::Less => {
+                    if let Some(tag) = left.next() {
+                        result.push(tag);
+                    }
+                }
+                Ordering::Greater => {
+                    if let Some(tag) = right.next() {
+                        result.push(tag);
+                    }
+                }
+                Ordering::Equal => {
+                    if let Some(tag) = left.next() {
+                        result.push(tag);
+                    }
+                    right.next();
+                }
+            }
+        }
+
+        result.extend(left);
+        result.extend(right);
+
+        self.tags = result;
+    }
+}
+
+impl BitXorAssign for StringTagCollection {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        let left_len = self.tags.len();
+        let right_len = rhs.tags.len();
+        let capacity = left_len.saturating_add(right_len);
+        let mut result = SmallVec::with_capacity(capacity);
+        let mut left = std::mem::take(&mut self.tags).into_iter().peekable();
+        let mut right = rhs.tags.into_iter().peekable();
+
+        // Symmetric difference (elements in either but not both).
+        while let (Some(left_tag), Some(right_tag)) = (left.peek(), right.peek()) {
+            match left_tag.cmp(right_tag) {
+                Ordering::Less => {
+                    if let Some(tag) = left.next() {
+                        result.push(tag);
+                    }
+                }
+                Ordering::Greater => {
+                    if let Some(tag) = right.next() {
+                        result.push(tag);
+                    }
+                }
+                Ordering::Equal => {
+                    // Skip elements that are in both.
+                    left.next();
+                    right.next();
+                }
+            }
+        }
+
+        result.extend(left);
+        result.extend(right);
+
+        self.tags = result;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_collection_intersection_works() {
+        let tags1 = StringTagCollection::from_strs(&["food", "fruit", "red"]);
+        let tags2 = StringTagCollection::from_strs(&["food", "vegetable", "green"]);
+        let tags3 = StringTagCollection::from_strs(&["electronics", "gadget"]);
+
+        assert!(tags1.intersects(&tags2));
+        assert!(!tags1.intersects(&tags3));
+        assert!(!tags2.intersects(&tags3));
+
+        let intersection = tags1.intersection(&tags2);
+        assert_eq!(intersection.len(), 1);
+        assert!(intersection.contains("food"));
+    }
+
+    #[test]
+    fn string_collection_contains_works() {
+        let tags = StringTagCollection::from_strs(&["food", "fruit", "red"]);
+
+        assert!(tags.contains("food"));
+        assert!(tags.contains("fruit"));
+        assert!(tags.contains("red"));
+        assert!(!tags.contains("vegetable"));
+    }
+
+    #[test]
+    fn string_collection_add_remove_works() {
+        let mut tags = StringTagCollection::from_strs(&["food", "fruit"]);
+
+        assert_eq!(tags.len(), 2);
+        assert!(!tags.contains("red"));
+        assert!(!tags.is_empty());
+
+        tags.add("red");
+        assert_eq!(tags.len(), 3);
+        assert!(tags.contains("red"));
+        assert!(!tags.is_empty());
+
+        tags.remove("fruit");
+        assert_eq!(tags.len(), 2);
+        assert!(!tags.contains("fruit"));
+        assert!(!tags.is_empty());
+    }
+
+    #[test]
+    fn string_collection_is_empty_works() {
+        let empty = StringTagCollection::empty();
+        assert!(empty.is_empty());
+
+        let empty_from_strs = StringTagCollection::from_strs(&[]);
+        assert!(empty_from_strs.is_empty());
+
+        let tags = StringTagCollection::from_strs(&["food"]);
+        assert!(!tags.is_empty());
+    }
+
+    #[test]
+    fn string_collection_deduplicates_tags() {
+        let tags = StringTagCollection::from_strs(&["food", "fruit", "food", "red", "fruit"]);
+
+        assert_eq!(tags.len(), 3);
+        assert!(tags.contains("food"));
+        assert!(tags.contains("fruit"));
+        assert!(tags.contains("red"));
+    }
+
+    #[test]
+    fn string_collection_maintains_sorted_order() {
+        let tags = StringTagCollection::from_strs(&["zebra", "apple", "banana"]);
+
+        // The internal vector should be sorted
+        assert_eq!(tags.tags, ["apple", "banana", "zebra"].into());
+    }
+
+    #[test]
+    fn string_collection_bitwise_and_intersection() {
+        let tags1 = StringTagCollection::from_strs(&["a", "b", "c"]);
+        let tags2 = StringTagCollection::from_strs(&["b", "c", "d"]);
+
+        let result = tags1 & tags2;
+        assert_eq!(result.len(), 2);
+        assert!(result.contains("b"));
+        assert!(result.contains("c"));
+        assert!(!result.contains("a"));
+        assert!(!result.contains("d"));
+    }
+
+    #[test]
+    fn string_collection_bitwise_or_union() {
+        let tags1 = StringTagCollection::from_strs(&["a", "b"]);
+        let tags2 = StringTagCollection::from_strs(&["c", "d"]);
+
+        let result = tags1 | tags2;
+        assert_eq!(result.len(), 4);
+        assert!(result.contains("a"));
+        assert!(result.contains("b"));
+        assert!(result.contains("c"));
+        assert!(result.contains("d"));
+    }
+
+    #[test]
+    fn string_collection_bitwise_or_with_overlap() {
+        let tags1 = StringTagCollection::from_strs(&["a", "b", "c"]);
+        let tags2 = StringTagCollection::from_strs(&["b", "c", "d"]);
+
+        let result = tags1 | tags2;
+        assert_eq!(result.len(), 4);
+        assert!(result.contains("a"));
+        assert!(result.contains("b"));
+        assert!(result.contains("c"));
+        assert!(result.contains("d"));
+    }
+
+    #[test]
+    fn string_collection_bitwise_or_prefers_right_when_smaller() {
+        let tags1 = StringTagCollection::from_strs(&["b", "d"]);
+        let tags2 = StringTagCollection::from_strs(&["a", "c"]);
+
+        let result = tags1 | tags2;
+        assert_eq!(result.tags, ["a", "b", "c", "d"].into());
+    }
+
+    #[test]
+    fn string_collection_bitwise_xor_symmetric_difference() {
+        let tags1 = StringTagCollection::from_strs(&["a", "b", "c"]);
+        let tags2 = StringTagCollection::from_strs(&["b", "c", "d"]);
+
+        let result = tags1 ^ tags2;
+        assert_eq!(result.len(), 2);
+        assert!(result.contains("a"));
+        assert!(result.contains("d"));
+        assert!(!result.contains("b"));
+        assert!(!result.contains("c"));
+    }
+
+    #[test]
+    fn string_collection_bitwise_xor_prefers_right_when_smaller() {
+        let tags1 = StringTagCollection::from_strs(&["b"]);
+        let tags2 = StringTagCollection::from_strs(&["a"]);
+
+        let result = tags1 ^ tags2;
+        assert_eq!(result.tags, ["a", "b"].into());
+    }
+
+    #[test]
+    fn string_collection_bitwise_assign_operations() {
+        let tags1 = StringTagCollection::from_strs(&["a", "b"]);
+        let tags2 = StringTagCollection::from_strs(&["b", "c"]);
+
+        // Test &=
+        let mut and = tags1.clone();
+        and &= tags2.clone();
+        assert_eq!(and.len(), 1);
+        assert!(and.contains("b"));
+
+        // Test |=
+        let mut or = tags1.clone();
+        or |= tags2.clone();
+        assert_eq!(or.len(), 3);
+        assert!(or.contains("a"));
+        assert!(or.contains("b"));
+        assert!(or.contains("c"));
+
+        // Test ^=
+        let mut xor = tags1.clone();
+        xor ^= tags2.clone();
+        assert_eq!(xor.len(), 2);
+        assert!(xor.contains("a"));
+        assert!(xor.contains("c"));
+        assert!(!xor.contains("b"));
+    }
+
+    #[test]
+    fn string_collection_bitwise_assign_advances_right_when_smaller() {
+        let mut and = StringTagCollection::from_strs(&["c"]);
+        let and_rhs = StringTagCollection::from_strs(&["a", "c"]);
+        and &= and_rhs;
+        assert_eq!(and.tags, ["c"].into());
+
+        let mut or = StringTagCollection::from_strs(&["c"]);
+        let or_rhs = StringTagCollection::from_strs(&["a", "c"]);
+        or |= or_rhs;
+        assert_eq!(or.tags, ["a", "c"].into());
+
+        let mut xor = StringTagCollection::from_strs(&["c"]);
+        let xor_rhs = StringTagCollection::from_strs(&["a"]);
+        xor ^= xor_rhs;
+        assert_eq!(xor.tags, ["a", "c"].into());
+    }
+
+    #[test]
+    fn string_collection_assign_operations_preserve_efficiency() {
+        // This test verifies that assignment operations work correctly
+        // and don't break the sorted order invariant
+        let mut tags1 = StringTagCollection::from_strs(&["apple", "banana", "cherry"]);
+        let tags2 = StringTagCollection::from_strs(&["banana", "date", "elderberry"]);
+
+        // Test &= preserves sorted order
+        tags1 &= tags2.clone();
+        assert_eq!(tags1.tags, ["banana"].into());
+        assert_eq!(tags1.len(), 1);
+
+        // Reset and test |=
+        let mut tags1 = StringTagCollection::from_strs(&["apple", "banana"]);
+        tags1 |= tags2.clone();
+        assert_eq!(tags1.tags, ["apple", "banana", "date", "elderberry"].into());
+        assert_eq!(tags1.len(), 4);
+
+        // Reset and test ^=
+        let mut tags1 = StringTagCollection::from_strs(&["apple", "banana", "cherry"]);
+        tags1 ^= tags2;
+        assert_eq!(tags1.tags, ["apple", "cherry", "date", "elderberry"].into());
+        assert_eq!(tags1.len(), 4);
+    }
+}


### PR DESCRIPTION
Introduce a new `tags` module with a `TagCollection` trait and a `StringTagCollection` implementation backed by `SmallVec`. Update `Item` to carry a generic tag collection and expose tag accessors.