### PR TITLE
Add public prelude and tighten internal APIs

### DIFF
--- a/src/fixtures/graph.rs
+++ b/src/fixtures/graph.rs
@@ -306,7 +306,7 @@ mod tests {
     use super::{GraphFixture, GraphNodeFixture, build_graph_from_fixture};
     use crate::{
         fixtures::{Fixture, FixtureError},
-        graph::node::OutputMode,
+        graph::OutputMode,
     };
 
     #[test]

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -198,7 +198,9 @@ impl<'a> PromotionGraphBuilder<'a> {
     /// # Errors
     ///
     /// Returns a [`GraphError`] if any validation rule is violated.
-    pub fn build(self) -> Result<(StableDiGraph<LayerNode<'a>, LayerEdge>, NodeIndex), GraphError> {
+    pub(crate) fn build(
+        self,
+    ) -> Result<(StableDiGraph<LayerNode<'a>, LayerEdge>, NodeIndex), GraphError> {
         // 1. Root must be set
         let root = self.root.ok_or(GraphError::NoRoot)?;
 

--- a/src/graph/edge.rs
+++ b/src/graph/edge.rs
@@ -2,7 +2,7 @@
 
 /// Edge weight in a promotion graph, describing which items flow along this edge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LayerEdge {
+pub(crate) enum LayerEdge {
     /// All items (promoted and unpromoted) flow along this edge.
     /// Used with [`super::node::OutputMode::PassThrough`] nodes.
     All,

--- a/src/graph/error.rs
+++ b/src/graph/error.rs
@@ -4,7 +4,7 @@ use rusty_money::MoneyError;
 use thiserror::Error;
 
 use crate::{
-    graph::node::PromotionLayerKey, items::groups::ItemGroupError, promotions::PromotionKey,
+    graph::PromotionLayerKey, items::groups::ItemGroupError, promotions::PromotionKey,
     solvers::SolverError,
 };
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -10,25 +10,24 @@ use rustc_hash::FxHashMap;
 use rusty_money::Money;
 use smallvec::SmallVec;
 
-use crate::{
-    graph::{
-        builder::PromotionGraphBuilder,
-        edge::LayerEdge,
-        error::GraphError,
-        evaluation::{TrackedItem, evaluate_node},
-        node::{LayerNode, OutputMode},
-        result::LayeredSolverResult,
-    },
-    items::groups::ItemGroup,
-    promotions::Promotion,
-    solvers::ilp::observer::ILPObserver,
+use self::{
+    edge::LayerEdge,
+    evaluation::{TrackedItem, evaluate_node},
+    node::LayerNode,
 };
+use crate::{items::groups::ItemGroup, promotions::Promotion, solvers::ilp::ILPObserver};
 
 pub mod builder;
-pub mod edge;
 pub mod error;
-pub mod node;
 pub mod result;
+
+pub(crate) mod edge;
+pub(crate) mod node;
+
+pub use builder::PromotionGraphBuilder;
+pub use error::GraphError;
+pub use node::{OutputMode, PromotionLayerKey};
+pub use result::LayeredSolverResult;
 
 mod evaluation;
 

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -29,7 +29,7 @@ new_key_type! {
 
 /// A node in the promotion graph representing a layer of competing promotions.
 #[derive(Debug, Clone)]
-pub struct LayerNode<'a> {
+pub(crate) struct LayerNode<'a> {
     /// Key for the human-readable name for this layer
     pub key: PromotionLayerKey,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod discounts;
 pub mod fixtures;
 pub mod graph;
 pub mod items;
+pub mod prelude;
 pub mod pricing;
 pub mod products;
 pub mod promotions;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,34 @@
+//! Dante prelude.
+//!
+//! Convenience exports for common library consumers.
+
+pub use crate::{
+    basket::{Basket, BasketError},
+    discounts::{DiscountError, SimpleDiscount},
+    graph::{GraphError, LayeredSolverResult, OutputMode, PromotionGraph, PromotionGraphBuilder},
+    items::{
+        Item,
+        groups::{ItemGroup, ItemGroupError},
+    },
+    products::{Product, ProductKey},
+    promotions::{
+        Promotion, PromotionKey, PromotionMeta, PromotionSlotKey,
+        budget::PromotionBudget,
+        promotion,
+        types::{
+            DirectDiscountPromotion, MixAndMatchDiscount, MixAndMatchPromotion, MixAndMatchSlot,
+            PositionalDiscountPromotion,
+        },
+    },
+    receipt::{Receipt, ReceiptError},
+    solvers::{
+        Solver, SolverError, SolverResult,
+        ilp::{
+            ILPObserver, ILPSolver, NoopObserver,
+            renderers::typst::{MultiLayerRenderer, TypstRenderError, TypstRenderer},
+        },
+    },
+    tags::{collection::TagCollection, string::StringTagCollection},
+};
+
+pub use crate::promotions::prelude::*;

--- a/src/promotions/mod.rs
+++ b/src/promotions/mod.rs
@@ -4,10 +4,11 @@ use std::sync::Arc;
 
 use slotmap::{SecondaryMap, new_key_type};
 
-use crate::{graph::node::PromotionLayerKey, solvers::ilp::promotions::ILPPromotion};
+use crate::{graph::PromotionLayerKey, solvers::ilp::ILPPromotion};
 
 pub mod applications;
 pub mod budget;
+pub mod prelude;
 pub mod types;
 
 new_key_type! {

--- a/src/promotions/prelude.rs
+++ b/src/promotions/prelude.rs
@@ -1,0 +1,7 @@
+//! Promotion extension prelude.
+//!
+//! Use this when implementing custom promotion types.
+
+pub use crate::solvers::ilp::{
+    ILPPromotion, ILPPromotionVars, ILPState, PromotionVars, i64_to_f64_exact,
+};

--- a/src/solvers/ilp/mod.rs
+++ b/src/solvers/ilp/mod.rs
@@ -1,7 +1,6 @@
 //! ILP Solver
 
 use good_lp::{Expression, ProblemVariables, Solution, SolverModel, Variable, variable};
-use num_traits::ToPrimitive;
 use rusty_money::{Money, iso::Currency};
 use smallvec::{SmallVec, smallvec};
 
@@ -10,23 +9,21 @@ use good_lp::solvers::highs::highs as default_solver;
 #[cfg(all(not(feature = "solver-highs"), feature = "solver-microlp"))]
 use good_lp::solvers::microlp::microlp as default_solver;
 
+use crate::solvers::ilp::state::{ConstraintRelation, ILPConstraint};
 use crate::{
     items::groups::ItemGroup,
     promotions::{Promotion, applications::PromotionApplication},
-    solvers::{
-        Solver, SolverError, SolverResult,
-        ilp::{
-            observer::{ILPObserver, NoopObserver},
-            promotions::{ILPPromotion, PromotionInstances},
-            state::{ConstraintRelation, ILPConstraint, ILPState},
-        },
-    },
+    solvers::{Solver, SolverError, SolverResult, ilp::promotions::PromotionInstances},
 };
 
 pub mod observer;
-pub mod promotions;
+pub(crate) mod promotions;
 pub mod renderers;
-pub mod state;
+pub(crate) mod state;
+
+pub use observer::{ILPObserver, NoopObserver};
+pub use promotions::{ILPPromotion, ILPPromotionVars, PromotionVars, i64_to_f64_exact};
+pub use state::ILPState;
 
 /// Binary threshold for determining truthiness
 pub const BINARY_THRESHOLD: f64 = 0.5;
@@ -356,13 +353,6 @@ fn apply_promotion_applications<'b>(
     }
 
     Ok((affected_items, used_items, total))
-}
-
-/// Convert an `i64` to an `f64` if it can be represented exactly.
-fn i64_to_f64_exact(v: i64) -> Option<f64> {
-    let f = v.to_f64()?;
-
-    (f.to_i64() == Some(v)).then_some(f)
 }
 
 #[cfg(test)]

--- a/src/solvers/ilp/observer.rs
+++ b/src/solvers/ilp/observer.rs
@@ -5,7 +5,7 @@ use std::any::Any;
 use good_lp::{Expression, Variable};
 use petgraph::graph::NodeIndex;
 
-use crate::{graph::node::PromotionLayerKey, promotions::PromotionKey};
+use crate::{graph::PromotionLayerKey, promotions::PromotionKey};
 
 /// Observer trait for capturing ILP formulation as it's built.
 ///

--- a/src/solvers/ilp/promotions/mod.rs
+++ b/src/solvers/ilp/promotions/mod.rs
@@ -22,7 +22,7 @@ mod positional_discount;
 
 /// Collection of promotion instances for a solve operation
 #[derive(Debug)]
-pub struct PromotionInstances<'a> {
+pub(crate) struct PromotionInstances<'a> {
     instances: SmallVec<[PromotionInstance<'a>; 5]>,
 }
 
@@ -32,7 +32,7 @@ impl<'a> PromotionInstances<'a> {
     /// # Errors
     ///
     /// Returns [`SolverError`] if any applicable promotion fails to add variables.
-    pub fn from_promotions(
+    pub(crate) fn from_promotions(
         promotions: &[&'a dyn ILPPromotion],
         item_group: &ItemGroup<'_>,
         state: &mut ILPState,
@@ -50,7 +50,7 @@ impl<'a> PromotionInstances<'a> {
     }
 
     /// Iterate over instances
-    pub fn iter(&self) -> impl Iterator<Item = &PromotionInstance<'a>> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &PromotionInstance<'a>> {
         self.instances.iter()
     }
 
@@ -59,7 +59,7 @@ impl<'a> PromotionInstances<'a> {
     /// Contributes each promotion's decision variables for the given item to the
     /// presence/exclusivity constraint expression.
     #[must_use]
-    pub fn add_item_presence_term(&self, expr: Expression, item_idx: usize) -> Expression {
+    pub(crate) fn add_item_presence_term(&self, expr: Expression, item_idx: usize) -> Expression {
         let mut updated_expr = expr;
 
         for instance in &self.instances {
@@ -72,7 +72,7 @@ impl<'a> PromotionInstances<'a> {
 
 /// A promotion instance that pairs a promotion with its solver variables
 #[derive(Debug)]
-pub struct PromotionInstance<'a> {
+pub(crate) struct PromotionInstance<'a> {
     /// The promotion being solved
     promotion: &'a dyn ILPPromotion,
 
@@ -92,7 +92,7 @@ impl<'a> PromotionInstance<'a> {
     ///
     /// Returns [`SolverError`] if the promotion fails to add variables (for example, due to
     /// invalid indices, discount errors, or non-representable coefficients).
-    pub fn new(
+    pub(crate) fn new(
         promotion: &'a dyn ILPPromotion,
         item_group: &ItemGroup<'_>,
         state: &mut ILPState,
@@ -115,7 +115,7 @@ impl<'a> PromotionInstance<'a> {
     /// This is called while building the per-item presence/exclusivity constraint that
     /// enforces each item is either at full price or used by exactly one promotion.
     #[must_use]
-    pub fn add_item_presence_term(&self, expr: Expression, item_idx: usize) -> Expression {
+    pub(crate) fn add_item_presence_term(&self, expr: Expression, item_idx: usize) -> Expression {
         match &self.vars {
             Some(vars) => vars.add_item_participation_term(expr, item_idx),
             None => expr,
@@ -131,7 +131,8 @@ impl<'a> PromotionInstance<'a> {
     ///
     /// Returns `SolverError` if a selected item index is invalid (missing from the item group),
     /// or if the discount for a selected item cannot be computed.
-    pub fn calculate_item_discounts(
+    #[cfg(test)]
+    pub(crate) fn calculate_item_discounts(
         &self,
         solution: &dyn Solution,
         item_group: &ItemGroup<'_>,
@@ -151,7 +152,7 @@ impl<'a> PromotionInstance<'a> {
     ///
     /// Returns [`SolverError`] if a selected item index is invalid (missing from the item group),
     /// or if the discount for a selected item cannot be computed.
-    pub fn calculate_item_applications<'b>(
+    pub(crate) fn calculate_item_applications<'b>(
         &self,
         solution: &dyn Solution,
         item_group: &ItemGroup<'b>,

--- a/src/solvers/ilp/renderers/typst/mod.rs
+++ b/src/solvers/ilp/renderers/typst/mod.rs
@@ -36,7 +36,7 @@ use slotmap::SlotMap;
 use smallvec::SmallVec;
 
 use crate::{
-    graph::node::PromotionLayerKey,
+    graph::PromotionLayerKey,
     items::groups::ItemGroup,
     products::{Product, ProductKey},
     promotions::{PromotionKey, PromotionMeta},

--- a/tests/custom_promotion_extensibility.rs
+++ b/tests/custom_promotion_extensibility.rs
@@ -11,17 +11,15 @@ use dante::{
     items::{Item, groups::ItemGroup},
     products::ProductKey,
     promotions::{
-        PromotionKey, applications::PromotionApplication, budget::PromotionBudget,
+        PromotionKey,
+        applications::PromotionApplication,
+        budget::PromotionBudget,
+        prelude::{ILPPromotion, ILPPromotionVars, ILPState, PromotionVars, i64_to_f64_exact},
         types::DirectDiscountPromotion,
     },
     solvers::{
         Solver, SolverError,
-        ilp::{
-            BINARY_THRESHOLD, ILPSolver,
-            observer::ILPObserver,
-            promotions::{ILPPromotion, ILPPromotionVars, PromotionVars, i64_to_f64_exact},
-            state::ILPState,
-        },
+        ilp::{BINARY_THRESHOLD, ILPSolver, observer::ILPObserver},
     },
     tags::string::StringTagCollection,
 };


### PR DESCRIPTION
Expose common consumer imports via `prelude` modules, re-export graph/ILP types at module roots, and make graph and ILP internals `pub(crate)` with updated import paths.