### PR TITLE
Add delete product endpoint and repository support

### DIFF
--- a/crates/json-api/src/products/http/errors.rs
+++ b/crates/json-api/src/products/http/errors.rs
@@ -24,6 +24,11 @@ impl From<ProductsRepositoryError> for StatusError {
 
                 StatusError::internal_server_error()
             }
+            ProductsRepositoryError::NotFound => {
+                error!("product not found");
+
+                StatusError::not_found()
+            }
         }
     }
 }

--- a/crates/json-api/src/products/http/handlers/create.rs
+++ b/crates/json-api/src/products/http/handlers/create.rs
@@ -103,6 +103,10 @@ mod tests {
             .withf(move |new| *new == NewProduct { uuid, price: 100 })
             .return_once(move |_| Ok(product));
 
+        repo.expect_get_products().never();
+        repo.expect_update_product().never();
+        repo.expect_delete_product().never();
+
         let mut res = TestClient::post("http://example.com/products")
             .json(&json!({ "uuid": uuid, "price": 100 }))
             .send(&make_service(repo))
@@ -129,6 +133,10 @@ mod tests {
             .withf(move |new| *new == NewProduct { uuid, price: 100 })
             .return_once(|_| Err(ProductsRepositoryError::AlreadyExists));
 
+        repo.expect_get_products().never();
+        repo.expect_update_product().never();
+        repo.expect_delete_product().never();
+
         let res = TestClient::post("http://example.com/products")
             .json(&json!({ "uuid": uuid, "price": 100 }))
             .send(&make_service(repo))
@@ -149,6 +157,10 @@ mod tests {
             .once()
             .withf(move |new| *new == NewProduct { uuid, price: 100 })
             .return_once(|_| Err(ProductsRepositoryError::InvalidData));
+
+        repo.expect_get_products().never();
+        repo.expect_update_product().never();
+        repo.expect_delete_product().never();
 
         let res = TestClient::post("http://example.com/products")
             .json(&json!({ "uuid": uuid, "price": 100 }))

--- a/crates/json-api/src/products/http/handlers/delete.rs
+++ b/crates/json-api/src/products/http/handlers/delete.rs
@@ -1,0 +1,110 @@
+//! Delete Product Handler
+
+use std::sync::Arc;
+
+use salvo::{oapi::extract::PathParam, prelude::*};
+use uuid::Uuid;
+
+use crate::{extensions::*, state::State};
+
+/// Delete Product Handler
+#[endpoint(
+    tags("products"),
+    summary = "Delete Product",
+    responses(
+        (status_code = StatusCode::OK, description = "Product deleted"),
+        (status_code = StatusCode::NOT_FOUND, description = "Product not found"),
+        (status_code = StatusCode::BAD_REQUEST, description = "Bad Request"),
+        (status_code = StatusCode::INTERNAL_SERVER_ERROR, description = "Internal Server Error"),
+    ),
+)]
+pub(crate) async fn handler(
+    uuid: PathParam<Uuid>,
+    depot: &mut Depot,
+) -> Result<StatusCode, StatusError> {
+    depot
+        .obtain_or_500::<Arc<State>>()?
+        .products
+        .delete_product(uuid.into_inner())
+        .await
+        .map_err(StatusError::from)?;
+
+    Ok(StatusCode::OK)
+}
+
+#[cfg(test)]
+mod tests {
+    use salvo::{affix_state::inject, test::TestClient};
+    use testresult::TestResult;
+
+    use crate::products::{MockProductsRepository, ProductsRepositoryError};
+
+    use super::{super::tests::*, *};
+
+    fn make_service(repo: MockProductsRepository) -> Service {
+        let state = Arc::new(State::new(Arc::new(repo)));
+
+        let router = Router::new()
+            .hoop(inject(state))
+            .push(Router::with_path("products/{uuid}").delete(handler));
+
+        Service::new(router)
+    }
+
+    #[tokio::test]
+    async fn test_delete_product_success() -> TestResult {
+        let uuid = Uuid::now_v7();
+
+        make_product(uuid);
+
+        let mut repo = MockProductsRepository::new();
+
+        repo.expect_delete_product()
+            .once()
+            .withf(move |u| *u == uuid)
+            .return_once(move |_| Ok(()));
+
+        let res = TestClient::delete(format!("http://example.com/products/{uuid}"))
+            .send(&make_service(repo))
+            .await;
+
+        assert_eq!(res.status_code, Some(StatusCode::OK));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_delete_product_invalid_uuid_returns_400() -> TestResult {
+        let res = TestClient::delete("http://example.com/products/123")
+            .send(&make_service(MockProductsRepository::new()))
+            .await;
+
+        assert_eq!(res.status_code, Some(StatusCode::BAD_REQUEST));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_delete_product_not_found_returns_404() -> TestResult {
+        let uuid = Uuid::now_v7();
+
+        let mut repo = MockProductsRepository::new();
+
+        repo.expect_delete_product()
+            .once()
+            .withf(move |u| *u == uuid)
+            .return_once(|_| Err(ProductsRepositoryError::InvalidReference));
+
+        repo.expect_create_product().never();
+        repo.expect_get_products().never();
+        repo.expect_update_product().never();
+
+        let res = TestClient::delete(format!("http://example.com/products/{uuid}"))
+            .send(&make_service(repo))
+            .await;
+
+        assert_eq!(res.status_code, Some(StatusCode::BAD_REQUEST));
+
+        Ok(())
+    }
+}

--- a/crates/json-api/src/products/http/handlers/index.rs
+++ b/crates/json-api/src/products/http/handlers/index.rs
@@ -98,6 +98,10 @@ mod tests {
 
         repo.expect_get_products().once().return_once(|| Ok(vec![]));
 
+        repo.expect_create_product().never();
+        repo.expect_update_product().never();
+        repo.expect_delete_product().never();
+
         let res = TestClient::get("http://example.com/products")
             .send(&make_service(repo))
             .await;
@@ -112,6 +116,10 @@ mod tests {
         let mut repo = MockProductsRepository::new();
 
         repo.expect_get_products().once().return_once(|| Ok(vec![]));
+
+        repo.expect_create_product().never();
+        repo.expect_update_product().never();
+        repo.expect_delete_product().never();
 
         let response: ProductsResponse = TestClient::get("http://example.com/products")
             .send(&make_service(repo))
@@ -135,6 +143,10 @@ mod tests {
             .once()
             .return_once(move || Ok(vec![make_product(uuid_a, 100), make_product(uuid_b, 200)]));
 
+        repo.expect_create_product().never();
+        repo.expect_update_product().never();
+        repo.expect_delete_product().never();
+
         let response: ProductsResponse = TestClient::get("http://example.com/products")
             .send(&make_service(repo))
             .await
@@ -155,6 +167,10 @@ mod tests {
         repo.expect_get_products()
             .once()
             .return_once(|| Err(ProductsRepositoryError::InvalidData));
+
+        repo.expect_create_product().never();
+        repo.expect_update_product().never();
+        repo.expect_delete_product().never();
 
         let res = TestClient::get("http://example.com/products")
             .send(&make_service(repo))

--- a/crates/json-api/src/products/http/handlers/mod.rs
+++ b/crates/json-api/src/products/http/handlers/mod.rs
@@ -1,6 +1,7 @@
 //! Product Handlers
 
 pub(crate) mod create;
+pub(crate) mod delete;
 pub(crate) mod index;
 pub(crate) mod update;
 

--- a/crates/json-api/src/products/sql/delete_product.sql
+++ b/crates/json-api/src/products/sql/delete_product.sql
@@ -1,0 +1,2 @@
+DELETE FROM products
+WHERE uuid = $1


### PR DESCRIPTION
Adds `DELETE /products/{uuid}` handler and repository method, returns 404 when the product does not exist.

Tightens up the  other handler tests by making sure unused repository methods aren't called.