### PR TITLE
Add testcontainers Postgres test harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,12 @@ checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -364,6 +370,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
@@ -390,6 +402,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
 ]
 
 [[package]]
@@ -590,6 +652,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -858,7 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "aes-gcm",
- "base64",
+ "base64 0.22.1",
  "hmac",
  "percent-encoding",
  "rand 0.8.5",
@@ -1025,6 +1088,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -1038,6 +1111,20 @@ name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1067,6 +1154,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.115",
 ]
@@ -1172,6 +1270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1246,6 +1345,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1393,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1412,7 +1528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c6ce0f549b84992322e48039adf0c483276f81993e401523ad12bd310b609ff"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.10.0",
  "cc",
  "cfg-if",
  "ext-php-rs-bindgen",
@@ -1433,7 +1549,7 @@ version = "0.72.1-extphprs.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4795dd0976bd7d7d321c49e88e836f8e5b5b2b481e089067e303f2945617458a"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cexpr",
  "ext-php-rs-clang-sys",
  "itertools 0.14.0",
@@ -1486,6 +1602,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1985,7 +2112,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2079,7 +2206,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http 1.4.0",
@@ -2254,6 +2381,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,7 +2420,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2293,6 +2435,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2431,6 +2588,17 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2647,17 +2815,20 @@ name = "lattice-app"
 version = "0.3.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "clap",
  "dotenvy",
  "jiff",
  "jiff-sqlx",
  "mockall",
+ "once_cell",
  "rand 0.8.5",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sqlx",
+ "testcontainers",
+ "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "uuid",
@@ -2818,7 +2989,7 @@ checksum = "0d61ec3e1ff8aaee8c5151688550c0363f85bc37845450764c31ff7584a33f38"
 dependencies = [
  "anyhow",
  "camino",
- "indexmap",
+ "indexmap 2.13.0",
  "parking_lot",
  "proc-macro2",
  "quote",
@@ -2858,7 +3029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf1045af93050bf3388d1c138426393fc131f6d9e46a65519da884c033ed730"
 dependencies = [
  "any_spawner",
- "base64",
+ "base64 0.22.1",
  "codee",
  "futures",
  "hydration_context",
@@ -2945,7 +3116,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.7.1",
 ]
@@ -2967,14 +3138,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9efb6a77b2389e62735b0b8157be9cc10a159eb4d1c3b864e99db9f297ada1b0"
 dependencies = [
  "ahash 0.8.12",
- "bitflags",
+ "bitflags 2.10.0",
  "const-str 0.3.2",
  "cssparser",
  "cssparser-color",
  "dashmap 5.5.3",
  "data-encoding",
  "getrandom 0.3.4",
- "indexmap",
+ "indexmap 2.13.0",
  "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",
@@ -3274,7 +3445,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "byteorder",
  "derive_builder",
  "getset",
@@ -3309,7 +3480,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3458,7 +3629,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3531,7 +3702,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "cssparser",
  "log",
  "phf",
@@ -3585,6 +3756,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3618,7 +3814,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3645,7 +3841,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
 ]
 
@@ -3983,7 +4179,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "memchr",
  "unicase",
 ]
@@ -4198,7 +4394,7 @@ dependencies = [
  "futures",
  "guardian",
  "hydration_context",
- "indexmap",
+ "indexmap 2.13.0",
  "or_poisoned",
  "paste",
  "pin-project-lite",
@@ -4243,11 +4439,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4256,7 +4461,27 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4303,7 +4528,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http 1.4.0",
@@ -4341,7 +4566,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4534,7 +4759,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4567,6 +4792,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4659,7 +4893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c9ab3bfb11d9e5bddb5c980730eceaa6594df790a66c2b9d4e3e7c3f5c7a49"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -4703,13 +4937,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d78680026cf132d26ba332ca008337920be3a083293581964d6ea06918711e7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "compact_str",
  "futures-util",
  "http 1.4.0",
- "indexmap",
+ "indexmap 2.13.0",
  "inventory",
  "mime-infer",
  "parking_lot",
@@ -4783,7 +5017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b5a977f41563f515d1fe13976142c1b96a8134c4bea58cd6a7ff044721f49f0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "chardetng",
@@ -4801,7 +5035,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "indexmap",
+ "indexmap 2.13.0",
  "mime",
  "mime-infer",
  "multer",
@@ -4836,7 +5070,7 @@ version = "0.89.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307c7f3a63f53b53f2c76f9a9e4da3d89cdf8f4ee840ae4bae45feb41f0f00af"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "etag",
  "futures-util",
  "http-body-util",
@@ -4885,6 +5119,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,7 +5160,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4915,7 +5173,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5034,7 +5292,7 @@ version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -5050,6 +5308,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -5074,12 +5343,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
 name = "server_fn"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353d02fa2886cd8dae0b8da0965289fa8f2ecc7df633d1ce965f62fdf9644d29"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "const-str 0.7.1",
  "const_format",
@@ -5314,7 +5614,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -5326,7 +5626,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "memchr",
  "native-tls",
@@ -5389,8 +5689,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
  "byteorder",
  "bytes",
  "crc",
@@ -5432,8 +5732,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -5522,6 +5822,29 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
 
 [[package]]
 name = "subtle"
@@ -5621,7 +5944,7 @@ dependencies = [
  "erased",
  "futures",
  "html-escape",
- "indexmap",
+ "indexmap 2.13.0",
  "itertools 0.14.0",
  "js-sys",
  "linear-map",
@@ -5665,6 +5988,44 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+dependencies = [
+ "testcontainers",
+]
 
 [[package]]
 name = "testing_table"
@@ -5865,6 +6226,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5917,7 +6293,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -5955,7 +6331,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -6218,7 +6594,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "der",
  "flate2",
  "log",
@@ -6236,7 +6612,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http 1.4.0",
  "httparse",
  "log",
@@ -6252,6 +6628,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6439,7 +6816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6498,9 +6875,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -6553,6 +6930,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6560,6 +6953,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -6945,7 +7344,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.115",
  "wasm-metadata",
@@ -6975,8 +7374,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap",
+ "bitflags 2.10.0",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -6995,7 +7394,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -7036,6 +7435,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -7196,7 +7605,7 @@ dependencies = [
  "flate2",
  "getrandom 0.4.1",
  "hmac",
- "indexmap",
+ "indexmap 2.13.0",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ rusty-money = "0.5.0"
 serde_norway = "0.9.42"
 slotmap = "1.1.1"
 smallvec = "1.15.1"
-testresult = "0.4.1"
 thiserror = "2.0.18"
 uuid = { version = "1.21.0", features = ["serde", "v7"] }
+
+# Dev
+once_cell = "1.20.2"
+testcontainers = "0.23.1"
+testcontainers-modules = { version = "0.11.2", features = ["postgres"] }
+testresult = "0.4.1"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -20,3 +20,8 @@ thiserror.workspace = true
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
 uuid.workspace = true
 zeroize = "1.8.2"
+
+[dev-dependencies]
+once_cell = { workspace = true }
+testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true }

--- a/crates/app/src/domain/carts/repository.rs
+++ b/crates/app/src/domain/carts/repository.rs
@@ -78,7 +78,7 @@ impl<'r> FromRow<'r, PgRow> for Cart {
 }
 
 fn try_get_amount(row: &PgRow, col: &str) -> Result<u64, sqlx::Error> {
-    let amount_i64: i64 = row.try_get("subtotal")?;
+    let amount_i64: i64 = row.try_get(col)?;
 
     u64::try_from(amount_i64).map_err(|e| sqlx::Error::ColumnDecode {
         index: col.to_string(),

--- a/crates/app/src/domain/carts/service.rs
+++ b/crates/app/src/domain/carts/service.rs
@@ -31,16 +31,6 @@ impl PgCartsService {
             repository: PgCartsRepository::new(),
         }
     }
-
-    async fn begin_tenant_transaction(
-        &self,
-        tenant: TenantUuid,
-    ) -> Result<sqlx::Transaction<'static, sqlx::Postgres>, CartsServiceError> {
-        self.db
-            .begin_tenant_transaction(tenant)
-            .await
-            .map_err(Into::into)
-    }
 }
 
 #[async_trait]
@@ -51,7 +41,7 @@ impl CartsService for PgCartsService {
         uuid: Uuid,
         point_in_time: Timestamp,
     ) -> Result<Cart, CartsServiceError> {
-        let mut tx = self.begin_tenant_transaction(tenant).await?;
+        let mut tx = self.db.begin_tenant_transaction(tenant).await?;
 
         let cart = self
             .repository
@@ -68,7 +58,7 @@ impl CartsService for PgCartsService {
         tenant: TenantUuid,
         cart: NewCart,
     ) -> Result<Cart, CartsServiceError> {
-        let mut tx = self.begin_tenant_transaction(tenant).await?;
+        let mut tx = self.db.begin_tenant_transaction(tenant).await?;
 
         let created = self.repository.create_cart(&mut tx, cart.uuid).await?;
 
@@ -78,7 +68,7 @@ impl CartsService for PgCartsService {
     }
 
     async fn delete_cart(&self, tenant: TenantUuid, uuid: Uuid) -> Result<(), CartsServiceError> {
-        let mut tx = self.begin_tenant_transaction(tenant).await?;
+        let mut tx = self.db.begin_tenant_transaction(tenant).await?;
 
         let rows_affected = self.repository.delete_cart(&mut tx, uuid).await?;
 
@@ -112,4 +102,145 @@ pub trait CartsService: Send + Sync {
 
     /// Deletes a cart with the given UUID.
     async fn delete_cart(&self, tenant: TenantUuid, uuid: Uuid) -> Result<(), CartsServiceError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use jiff::Timestamp;
+    use uuid::Uuid;
+
+    use crate::{domain::carts::models::NewCart, test::TestContext};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn create_cart_returns_correct_uuid() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        let cart = ctx
+            .carts
+            .create_cart(ctx.tenant_uuid, NewCart { uuid })
+            .await
+            .expect("create_cart should succeed");
+
+        assert_eq!(cart.uuid, uuid);
+        assert_eq!(cart.subtotal, 0);
+        assert_eq!(cart.total, 0);
+        assert!(cart.deleted_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_cart_returns_created_cart() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        ctx.carts
+            .create_cart(ctx.tenant_uuid, NewCart { uuid })
+            .await
+            .expect("create_cart should succeed");
+
+        let cart = ctx
+            .carts
+            .get_cart(ctx.tenant_uuid, uuid, Timestamp::now())
+            .await
+            .expect("get_cart should succeed");
+
+        assert_eq!(cart.uuid, uuid);
+        assert!(cart.deleted_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_cart_unknown_uuid_returns_not_found() {
+        let ctx = TestContext::new().await;
+
+        let result = ctx
+            .carts
+            .get_cart(ctx.tenant_uuid, Uuid::now_v7(), Timestamp::now())
+            .await;
+
+        assert!(
+            matches!(result, Err(CartsServiceError::NotFound)),
+            "expected NotFound, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_cart_duplicate_uuid_returns_already_exists() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        ctx.carts
+            .create_cart(ctx.tenant_uuid, NewCart { uuid })
+            .await
+            .expect("first create_cart should succeed");
+
+        let result = ctx
+            .carts
+            .create_cart(ctx.tenant_uuid, NewCart { uuid })
+            .await;
+
+        assert!(
+            matches!(result, Err(CartsServiceError::AlreadyExists)),
+            "expected AlreadyExists, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_cart_makes_it_not_found() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        ctx.carts
+            .create_cart(ctx.tenant_uuid, NewCart { uuid })
+            .await
+            .expect("create_cart should succeed");
+
+        ctx.carts
+            .delete_cart(ctx.tenant_uuid, uuid)
+            .await
+            .expect("delete_cart should succeed");
+
+        let result = ctx
+            .carts
+            .get_cart(ctx.tenant_uuid, uuid, Timestamp::now())
+            .await;
+
+        assert!(
+            matches!(result, Err(CartsServiceError::NotFound)),
+            "expected NotFound after deletion, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_cart_unknown_uuid_returns_not_found() {
+        let ctx = TestContext::new().await;
+
+        let result = ctx.carts.delete_cart(ctx.tenant_uuid, Uuid::now_v7()).await;
+
+        assert!(
+            matches!(result, Err(CartsServiceError::NotFound)),
+            "expected NotFound, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cart_not_visible_to_other_tenant() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        let tenant_b = ctx.create_tenant("Tenant B").await;
+
+        ctx.carts
+            .create_cart(ctx.tenant_uuid, NewCart { uuid })
+            .await
+            .expect("create_cart should succeed");
+
+        let result = ctx.carts.get_cart(tenant_b, uuid, Timestamp::now()).await;
+
+        assert!(
+            matches!(result, Err(CartsServiceError::NotFound)),
+            "expected NotFound for cross-tenant access, got {result:?}"
+        );
+    }
 }

--- a/crates/app/src/domain/carts/sql/create_cart.sql
+++ b/crates/app/src/domain/carts/sql/create_cart.sql
@@ -4,6 +4,8 @@ VALUES
     ($1)
 RETURNING
     uuid,
+    subtotal,
+    total,
     created_at,
     updated_at,
     deleted_at

--- a/crates/app/src/domain/carts/sql/delete_cart.sql
+++ b/crates/app/src/domain/carts/sql/delete_cart.sql
@@ -1,0 +1,4 @@
+UPDATE carts
+SET deleted_at = now()
+WHERE uuid = $1
+  AND deleted_at IS NULL

--- a/crates/app/src/domain/carts/sql/get_cart.sql
+++ b/crates/app/src/domain/carts/sql/get_cart.sql
@@ -1,5 +1,7 @@
 SELECT
     carts.uuid,
+    carts.subtotal,
+    carts.total,
     carts.created_at,
     carts.updated_at,
     carts.deleted_at

--- a/crates/app/src/domain/products/service.rs
+++ b/crates/app/src/domain/products/service.rs
@@ -31,16 +31,6 @@ impl PgProductsService {
             repository: PgProductsRepository::new(),
         }
     }
-
-    async fn begin_tenant_transaction(
-        &self,
-        tenant: TenantUuid,
-    ) -> Result<sqlx::Transaction<'static, sqlx::Postgres>, ProductsServiceError> {
-        self.db
-            .begin_tenant_transaction(tenant)
-            .await
-            .map_err(Into::into)
-    }
 }
 
 #[async_trait]
@@ -50,7 +40,7 @@ impl ProductsService for PgProductsService {
         tenant: TenantUuid,
         point_in_time: Timestamp,
     ) -> Result<Vec<Product>, ProductsServiceError> {
-        let mut tx = self.begin_tenant_transaction(tenant).await?;
+        let mut tx = self.db.begin_tenant_transaction(tenant).await?;
 
         let products = self
             .repository
@@ -68,7 +58,7 @@ impl ProductsService for PgProductsService {
         uuid: Uuid,
         point_in_time: Timestamp,
     ) -> Result<Product, ProductsServiceError> {
-        let mut tx = self.begin_tenant_transaction(tenant).await?;
+        let mut tx = self.db.begin_tenant_transaction(tenant).await?;
 
         let product = self
             .repository
@@ -85,7 +75,7 @@ impl ProductsService for PgProductsService {
         tenant: TenantUuid,
         product: NewProduct,
     ) -> Result<Product, ProductsServiceError> {
-        let mut tx = self.begin_tenant_transaction(tenant).await?;
+        let mut tx = self.db.begin_tenant_transaction(tenant).await?;
 
         let created = self
             .repository
@@ -103,7 +93,7 @@ impl ProductsService for PgProductsService {
         uuid: Uuid,
         update: ProductUpdate,
     ) -> Result<Product, ProductsServiceError> {
-        let mut tx = self.begin_tenant_transaction(tenant).await?;
+        let mut tx = self.db.begin_tenant_transaction(tenant).await?;
 
         let updated = self
             .repository
@@ -120,7 +110,7 @@ impl ProductsService for PgProductsService {
         tenant: TenantUuid,
         uuid: Uuid,
     ) -> Result<(), ProductsServiceError> {
-        let mut tx = self.begin_tenant_transaction(tenant).await?;
+        let mut tx = self.db.begin_tenant_transaction(tenant).await?;
 
         let rows_affected = self.repository.delete_product(&mut tx, uuid).await?;
 
@@ -173,4 +163,290 @@ pub trait ProductsService: Send + Sync {
         tenant: TenantUuid,
         uuid: Uuid,
     ) -> Result<(), ProductsServiceError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use jiff::Timestamp;
+    use uuid::Uuid;
+
+    use crate::{
+        domain::products::models::{NewProduct, ProductUpdate},
+        test::TestContext,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn create_product_returns_correct_uuid_and_price() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        let product = ctx
+            .products
+            .create_product(ctx.tenant_uuid, NewProduct { uuid, price: 999 })
+            .await
+            .expect("create_product should succeed");
+
+        assert_eq!(product.uuid, uuid);
+        assert_eq!(product.price, 999);
+        assert!(product.deleted_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_product_returns_created_product() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        ctx.products
+            .create_product(ctx.tenant_uuid, NewProduct { uuid, price: 1500 })
+            .await
+            .expect("create_product should succeed");
+
+        let product = ctx
+            .products
+            .get_product(ctx.tenant_uuid, uuid, Timestamp::now())
+            .await
+            .expect("get_product should succeed");
+
+        assert_eq!(product.uuid, uuid);
+        assert_eq!(product.price, 1500);
+        assert!(product.deleted_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_product_unknown_uuid_returns_not_found() {
+        let ctx = TestContext::new().await;
+
+        let result = ctx
+            .products
+            .get_product(ctx.tenant_uuid, Uuid::now_v7(), Timestamp::now())
+            .await;
+
+        assert!(
+            matches!(result, Err(ProductsServiceError::NotFound)),
+            "expected NotFound, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_products_returns_created_products() {
+        let ctx = TestContext::new().await;
+
+        let uuid_a = Uuid::now_v7();
+        let uuid_b = Uuid::now_v7();
+
+        ctx.products
+            .create_product(
+                ctx.tenant_uuid,
+                NewProduct {
+                    uuid: uuid_a,
+                    price: 100,
+                },
+            )
+            .await
+            .expect("create product A should succeed");
+
+        ctx.products
+            .create_product(
+                ctx.tenant_uuid,
+                NewProduct {
+                    uuid: uuid_b,
+                    price: 200,
+                },
+            )
+            .await
+            .expect("create product B should succeed");
+
+        let products = ctx
+            .products
+            .list_products(ctx.tenant_uuid, Timestamp::now())
+            .await
+            .expect("list_products should succeed");
+
+        let uuids: Vec<Uuid> = products.iter().map(|p| p.uuid).collect();
+
+        assert!(uuids.contains(&uuid_a), "product A should be in the list");
+        assert!(uuids.contains(&uuid_b), "product B should be in the list");
+    }
+
+    #[tokio::test]
+    async fn list_products_empty_when_none_created() {
+        let ctx = TestContext::new().await;
+
+        let products = ctx
+            .products
+            .list_products(ctx.tenant_uuid, Timestamp::now())
+            .await
+            .expect("list_products should succeed");
+
+        assert!(products.is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_product_reflects_new_price() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        ctx.products
+            .create_product(ctx.tenant_uuid, NewProduct { uuid, price: 500 })
+            .await
+            .expect("create_product should succeed");
+
+        let updated = ctx
+            .products
+            .update_product(
+                ctx.tenant_uuid,
+                uuid,
+                ProductUpdate {
+                    uuid: None,
+                    price: 750,
+                },
+            )
+            .await
+            .expect("update_product should succeed");
+
+        assert_eq!(updated.uuid, uuid);
+        assert_eq!(updated.price, 750);
+    }
+
+    #[tokio::test]
+    async fn update_product_unknown_uuid_returns_not_found() {
+        let ctx = TestContext::new().await;
+
+        let result = ctx
+            .products
+            .update_product(
+                ctx.tenant_uuid,
+                Uuid::now_v7(),
+                ProductUpdate {
+                    uuid: None,
+                    price: 100,
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(ProductsServiceError::NotFound)),
+            "expected NotFound, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_product_makes_it_not_found() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        ctx.products
+            .create_product(ctx.tenant_uuid, NewProduct { uuid, price: 300 })
+            .await
+            .expect("create_product should succeed");
+
+        ctx.products
+            .delete_product(ctx.tenant_uuid, uuid)
+            .await
+            .expect("delete_product should succeed");
+
+        let result = ctx
+            .products
+            .get_product(ctx.tenant_uuid, uuid, Timestamp::now())
+            .await;
+
+        assert!(
+            matches!(result, Err(ProductsServiceError::NotFound)),
+            "expected NotFound after deletion, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_product_unknown_uuid_returns_not_found() {
+        let ctx = TestContext::new().await;
+
+        let result = ctx
+            .products
+            .delete_product(ctx.tenant_uuid, Uuid::now_v7())
+            .await;
+
+        assert!(
+            matches!(result, Err(ProductsServiceError::NotFound)),
+            "expected NotFound, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_product_duplicate_uuid_returns_already_exists() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        ctx.products
+            .create_product(ctx.tenant_uuid, NewProduct { uuid, price: 100 })
+            .await
+            .expect("first create_product should succeed");
+
+        let result = ctx
+            .products
+            .create_product(ctx.tenant_uuid, NewProduct { uuid, price: 200 })
+            .await;
+
+        assert!(
+            matches!(result, Err(ProductsServiceError::AlreadyExists)),
+            "expected AlreadyExists, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn product_not_visible_to_other_tenant() {
+        let ctx = TestContext::new().await;
+        let tenant_b = ctx.create_tenant("Tenant B").await;
+
+        let product = ctx
+            .products
+            .create_product(
+                ctx.tenant_uuid,
+                NewProduct {
+                    uuid: Uuid::now_v7(),
+                    price: 100,
+                },
+            )
+            .await
+            .expect("create_product should succeed");
+
+        // Tenant B cannot see Tenant A's product
+        let result = ctx
+            .products
+            .get_product(tenant_b, product.uuid, Timestamp::now())
+            .await;
+
+        assert!(
+            matches!(result, Err(ProductsServiceError::NotFound)),
+            "expected NotFound for cross-tenant access, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn deleted_product_not_returned_in_list() {
+        let ctx = TestContext::new().await;
+        let uuid = Uuid::now_v7();
+
+        ctx.products
+            .create_product(ctx.tenant_uuid, NewProduct { uuid, price: 100 })
+            .await
+            .expect("create_product should succeed");
+
+        ctx.products
+            .delete_product(ctx.tenant_uuid, uuid)
+            .await
+            .expect("delete_product should succeed");
+
+        let products = ctx
+            .products
+            .list_products(ctx.tenant_uuid, Timestamp::now())
+            .await
+            .expect("list_products should succeed");
+
+        assert!(
+            !products.iter().any(|p| p.uuid == uuid),
+            "deleted product should not appear in list"
+        );
+    }
 }

--- a/crates/app/src/domain/tenants/service.rs
+++ b/crates/app/src/domain/tenants/service.rs
@@ -41,3 +41,131 @@ pub trait TenantsService: Send + Sync {
     /// Creates a new tenant.
     async fn create_tenant(&self, tenant: NewTenant) -> Result<Tenant, TenantsServiceError>;
 }
+
+#[cfg(test)]
+mod tests {
+    use jiff::Timestamp;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::test::TestContext;
+
+    #[tokio::test]
+    async fn create_tenant_returns_correct_uuid_and_name() {
+        let ctx = TestContext::new().await;
+        let svc = PgTenantsService::new(ctx.db.pool().clone());
+
+        let uuid = Uuid::now_v7();
+
+        let tenant = svc
+            .create_tenant(NewTenant {
+                uuid,
+                name: "Acme Corp".to_string(),
+            })
+            .await
+            .expect("create_tenant should succeed");
+
+        assert_eq!(tenant.uuid, uuid);
+        assert_eq!(tenant.name, "Acme Corp");
+        assert!(tenant.deleted_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn create_tenant_timestamps_are_set() {
+        let ctx = TestContext::new().await;
+        let svc = PgTenantsService::new(ctx.db.pool().clone());
+
+        let before = Timestamp::now();
+
+        let tenant = svc
+            .create_tenant(NewTenant {
+                uuid: Uuid::now_v7(),
+                name: "Timestamp Test".to_string(),
+            })
+            .await
+            .expect("create_tenant should succeed");
+
+        let after = Timestamp::now();
+
+        assert!(tenant.created_at >= before);
+        assert!(tenant.created_at <= after);
+    }
+
+    #[tokio::test]
+    async fn create_tenant_duplicate_uuid_returns_already_exists() {
+        let ctx = TestContext::new().await;
+        let svc = PgTenantsService::new(ctx.db.pool().clone());
+
+        let uuid = Uuid::now_v7();
+
+        svc.create_tenant(NewTenant {
+            uuid,
+            name: "First".to_string(),
+        })
+        .await
+        .expect("first create_tenant should succeed");
+
+        let result = svc
+            .create_tenant(NewTenant {
+                uuid,
+                name: "Second".to_string(),
+            })
+            .await;
+
+        assert!(
+            matches!(result, Err(TenantsServiceError::AlreadyExists)),
+            "expected AlreadyExists, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_tenant_duplicate_name_succeeds() {
+        let ctx = TestContext::new().await;
+        let svc = PgTenantsService::new(ctx.db.pool().clone());
+
+        // Name has no uniqueness constraint — two tenants may share a name
+        svc.create_tenant(NewTenant {
+            uuid: Uuid::now_v7(),
+            name: "Shared Name".to_string(),
+        })
+        .await
+        .expect("first create_tenant should succeed");
+
+        svc.create_tenant(NewTenant {
+            uuid: Uuid::now_v7(),
+            name: "Shared Name".to_string(),
+        })
+        .await
+        .expect("second create_tenant with same name should also succeed");
+    }
+
+    #[tokio::test]
+    async fn create_tenant_multiple_tenants_are_independent() {
+        let ctx = TestContext::new().await;
+        let svc = PgTenantsService::new(ctx.db.pool().clone());
+
+        let uuid_a = Uuid::now_v7();
+        let uuid_b = Uuid::now_v7();
+
+        let tenant_a = svc
+            .create_tenant(NewTenant {
+                uuid: uuid_a,
+                name: "Tenant A".to_string(),
+            })
+            .await
+            .expect("create tenant A should succeed");
+
+        let tenant_b = svc
+            .create_tenant(NewTenant {
+                uuid: uuid_b,
+                name: "Tenant B".to_string(),
+            })
+            .await
+            .expect("create tenant B should succeed");
+
+        assert_eq!(tenant_a.uuid, uuid_a);
+        assert_eq!(tenant_b.uuid, uuid_b);
+        assert_ne!(tenant_a.uuid, tenant_b.uuid);
+        assert_ne!(tenant_a.name, tenant_b.name);
+    }
+}

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -5,4 +5,7 @@ pub mod context;
 pub mod database;
 pub mod domain;
 
+#[cfg(test)]
+mod test;
+
 mod uuids;

--- a/crates/app/src/test/context.rs
+++ b/crates/app/src/test/context.rs
@@ -1,0 +1,156 @@
+//! Test context for service-level integration tests.
+
+use sqlx::{Connection, PgConnection, PgPool, query};
+use uuid::Uuid;
+
+use crate::{
+    database::Db,
+    domain::{
+        carts::PgCartsService,
+        products::PgProductsService,
+        tenants::{
+            PgTenantsService, TenantsService,
+            models::{NewTenant, TenantUuid},
+        },
+    },
+};
+
+use super::db::TestDb;
+
+/// Name of the non-superuser app role used for RLS testing.
+const APP_ROLE: &str = "lattice_app_test";
+const APP_ROLE_PASSWORD: &str = "lattice_app_test_pass";
+
+pub struct TestContext {
+    pub db: TestDb,
+    pub tenant_uuid: TenantUuid,
+    pub products: PgProductsService,
+    pub carts: PgCartsService,
+}
+
+impl TestContext {
+    pub async fn new() -> Self {
+        let test_db = TestDb::new().await;
+
+        // Build a non-superuser app pool so RLS policies are enforced.
+        // The superuser pool is only used for administrative setup (tenant creation).
+        let app_pool = Self::setup_app_pool(&test_db).await;
+        let db = Db::new(app_pool);
+
+        let tenant_uuid = Uuid::now_v7();
+
+        PgTenantsService::new(test_db.pool().clone())
+            .create_tenant(NewTenant {
+                uuid: tenant_uuid,
+                name: "Test Tenant".to_string(),
+            })
+            .await
+            .expect("Failed to create default test tenant");
+
+        Self {
+            products: PgProductsService::new(db.clone()),
+            carts: PgCartsService::new(db),
+            tenant_uuid: TenantUuid::from_uuid(tenant_uuid),
+            db: test_db,
+        }
+    }
+
+    /// Create an additional tenant — useful for RLS isolation tests.
+    pub async fn create_tenant(&self, name: &str) -> TenantUuid {
+        let uuid = Uuid::now_v7();
+
+        PgTenantsService::new(self.db.pool().clone())
+            .create_tenant(NewTenant {
+                uuid,
+                name: name.to_string(),
+            })
+            .await
+            .expect("Failed to create test tenant");
+
+        TenantUuid::from_uuid(uuid)
+    }
+
+    /// Create a non-superuser role (once per server) and return a pool connected as it.
+    ///
+    /// PostgreSQL superusers bypass RLS even with `FORCE ROW LEVEL SECURITY`, so service
+    /// tests that exercise isolation must connect via this restricted role.
+    async fn setup_app_pool(test_db: &TestDb) -> PgPool {
+        // `superuser_url` points at the test database as the superuser.
+        let su_url = &test_db.superuser_url;
+
+        // Derive a base URL pointing at the `postgres` maintenance database for
+        // server-level DDL (CREATE ROLE is server-scoped, not database-scoped).
+        let postgres_url = su_url.rsplit_once('/').map(|x| x.0).unwrap_or(su_url);
+        let postgres_url = format!("{postgres_url}/postgres");
+
+        let mut server_conn = PgConnection::connect(&postgres_url)
+            .await
+            .expect("Failed to connect to postgres database for role setup");
+
+        // Create the app role. Multiple parallel tests may race here; treat
+        // "role already exists" (42710) or the underlying unique violation (23505)
+        // as success — the role is present either way.
+        let create_result = query(&format!(
+            "CREATE ROLE {APP_ROLE} WITH LOGIN PASSWORD '{APP_ROLE_PASSWORD}' \
+               NOSUPERUSER NOCREATEDB NOCREATEROLE"
+        ))
+        .execute(&mut server_conn)
+        .await;
+
+        if let Err(sqlx::Error::Database(ref e)) = create_result {
+            if !matches!(e.code().as_deref(), Some("42710") | Some("23505")) {
+                create_result.expect("Failed to create app role");
+            }
+        } else {
+            create_result.expect("Failed to create app role");
+        }
+
+        // Grant CONNECT on the test database.
+        query(&format!(
+            "GRANT CONNECT ON DATABASE \"{}\" TO {APP_ROLE}",
+            test_db.name
+        ))
+        .execute(&mut server_conn)
+        .await
+        .expect("Failed to grant CONNECT on test database");
+
+        server_conn
+            .close()
+            .await
+            .expect("Failed to close server connection");
+
+        // Within the test database, grant schema and table privileges.
+        let mut db_conn = PgConnection::connect(su_url)
+            .await
+            .expect("Failed to connect to test database for privilege setup");
+
+        for stmt in [
+            format!("GRANT USAGE ON SCHEMA public TO {APP_ROLE}"),
+            format!(
+                "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO {APP_ROLE}"
+            ),
+            format!("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {APP_ROLE}"),
+        ] {
+            query(&stmt)
+                .execute(&mut db_conn)
+                .await
+                .expect("Failed to grant table privileges to app role");
+        }
+
+        db_conn
+            .close()
+            .await
+            .expect("Failed to close db connection");
+
+        // Connect as the non-superuser role.
+        let app_url = su_url.replacen(
+            "lattice_test:lattice_test_password",
+            &format!("{APP_ROLE}:{APP_ROLE_PASSWORD}"),
+            1,
+        );
+
+        PgPool::connect(&app_url)
+            .await
+            .expect("Failed to create app pool")
+    }
+}

--- a/crates/app/src/test/db.rs
+++ b/crates/app/src/test/db.rs
@@ -1,0 +1,358 @@
+//! Database test utilities and shared infrastructure
+
+use once_cell::sync::Lazy;
+use sqlx::{Connection, PgConnection, PgPool, Postgres, Transaction};
+use testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner};
+use testcontainers_modules::postgres::Postgres as PostgresImage;
+use tokio::sync::{OnceCell, mpsc};
+
+/// Validates a database name to prevent SQL injection
+///
+/// Database names must:
+/// - Be 1-63 characters long
+/// - Start with a letter or underscore
+/// - Contain only letters, digits, underscores, and dollar signs
+/// - Not be a PostgreSQL reserved word
+fn validate_database_name(name: &str) -> Result<(), String> {
+    if name.is_empty() || name.len() > 63 {
+        return Err("Database name must be 1-63 characters long".to_string());
+    }
+
+    // Must start with letter or underscore
+    if !name.chars().next().unwrap().is_ascii_alphabetic() && !name.starts_with('_') {
+        return Err("Database name must start with a letter or underscore".to_string());
+    }
+
+    // Must contain only valid characters
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+    {
+        return Err(
+            "Database name can only contain letters, digits, underscores, and dollar signs"
+                .to_string(),
+        );
+    }
+
+    // Check against some common PostgreSQL reserved words that could be problematic
+    let reserved_words = [
+        "user", "table", "select", "insert", "update", "delete", "drop", "create", "alter",
+        "index", "database", "schema", "role", "grant", "revoke",
+    ];
+
+    if reserved_words
+        .iter()
+        .any(|&word| name.eq_ignore_ascii_case(word))
+    {
+        return Err(format!("Database name '{name}' is a reserved word"));
+    }
+
+    Ok(())
+}
+
+/// Shared PostgreSQL container initialization
+async fn init_postgres_container() -> ContainerAsync<PostgresImage> {
+    PostgresImage::default()
+        .with_user("lattice_test")
+        .with_password("lattice_test_password")
+        .with_db_name("lattice_test")
+        .with_env_var("POSTGRES_INITDB_ARGS", "--auth-host=trust")
+        .start()
+        .await
+        .expect("Failed to start PostgreSQL container")
+}
+
+/// Shared PostgreSQL container that starts once and is reused across all tests
+static POSTGRES_CONTAINER: Lazy<OnceCell<ContainerAsync<PostgresImage>>> = Lazy::new(OnceCell::new);
+
+/// Cleanup channel for database cleanup requests
+static CLEANUP_SENDER: Lazy<OnceCell<mpsc::UnboundedSender<String>>> = Lazy::new(OnceCell::new);
+
+/// Initialize the cleanup background task
+async fn init_cleanup_task() -> mpsc::UnboundedSender<String> {
+    let (sender, mut receiver) = mpsc::unbounded_channel::<String>();
+
+    // Spawn background task to handle cleanup requests
+    tokio::spawn(async move {
+        while let Some(db_name) = receiver.recv().await {
+            // Perform async cleanup
+            if let Err(err) = cleanup_database(&db_name).await {
+                eprintln!("Failed to cleanup database '{db_name}': {err}");
+            }
+        }
+    });
+
+    sender
+}
+
+/// Drop a test database by name.
+async fn cleanup_database(db_name: &str) -> Result<(), sqlx::Error> {
+    if let Some(container) = POSTGRES_CONTAINER.get()
+        && let Ok(port) = container.get_host_port_ipv4(5432).await
+    {
+        let host = std::env::var("TESTCONTAINERS_HOST_OVERRIDE")
+            .unwrap_or_else(|_| "localhost".to_string());
+        let base_url =
+            format!("postgresql://lattice_test:lattice_test_password@{host}:{port}/postgres");
+
+        if let Ok(mut conn) = PgConnection::connect(&base_url).await {
+            // Validate database name before dropping
+            if validate_database_name(db_name).is_ok() {
+                let drop_query = format!("DROP DATABASE IF EXISTS \"{db_name}\"");
+                let _ = sqlx::query(&drop_query).execute(&mut conn).await;
+            }
+            let _ = conn.close().await;
+        }
+    }
+
+    Ok(())
+}
+
+/// Test database configuration
+///
+/// Each `TestDb` instance creates a uniquely named database within a shared PostgreSQL container.
+/// The database is automatically dropped when the `TestDb` instance goes out of scope.
+///
+/// ## Isolation model
+///
+/// Isolation is **database-level**: every test gets its own fresh database with migrations
+/// applied. Service methods commit their own transactions normally, so there is no
+/// auto-rollback mechanism. Tests do not need to do anything special to get clean state —
+/// it comes for free from the per-test database.
+///
+/// `cleanup().await` drops the database immediately rather than waiting for `Drop`. It is
+/// purely an optimisation for long test suites and is never required for correctness.
+#[derive(Debug, Clone)]
+pub struct TestDb {
+    /// PostgreSQL connection pool
+    pub pool: PgPool,
+
+    /// PostgreSQL database name
+    pub name: String,
+
+    /// The URL `pool` was connected with. Stored so callers (e.g. `TestContext`) can
+    /// derive alternate connection strings by substituting different credentials.
+    pub(super) superuser_url: String,
+}
+
+impl Drop for TestDb {
+    fn drop(&mut self) {
+        // Send cleanup request to background task
+        if let Some(sender) = CLEANUP_SENDER.get() {
+            let _ = sender.send(self.name.clone());
+        }
+    }
+}
+
+impl TestDb {
+    /// Create an isolated test database with a unique generated name.
+    #[allow(dead_code)]
+    pub async fn new() -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        let thread_id = std::thread::current().id();
+
+        let name =
+            format!("lattice_repo_test_{nanos}_{thread_id:?}").replace([':', ' ', '(', ')'], "");
+
+        Self::new_with_db_name(&name).await
+    }
+
+    /// Create an isolated test database with the given name.
+    #[allow(dead_code)]
+    pub async fn new_with_db_name(db_name: &str) -> Self {
+        let _cleanup_sender = CLEANUP_SENDER.get_or_init(init_cleanup_task).await;
+
+        if let Err(error) = validate_database_name(db_name) {
+            panic!("Invalid database name '{db_name}': {error}");
+        }
+
+        let container = POSTGRES_CONTAINER
+            .get_or_init(init_postgres_container)
+            .await;
+
+        let port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("Failed to get container port");
+
+        let host = std::env::var("TESTCONTAINERS_HOST_OVERRIDE")
+            .unwrap_or_else(|_| "localhost".to_string());
+
+        let base_url =
+            format!("postgresql://lattice_test:lattice_test_password@{host}:{port}/postgres");
+
+        let mut conn = PgConnection::connect(&base_url)
+            .await
+            .expect("Failed to connect to postgres database");
+
+        // Create the isolated test database
+        let create_db_query = format!("CREATE DATABASE \"{db_name}\"");
+
+        sqlx::query(&create_db_query)
+            .execute(&mut conn)
+            .await
+            .expect("Failed to create test database");
+
+        conn.close()
+            .await
+            .expect("Failed to close admin connection");
+
+        // Now connect to the isolated database
+        let database_url =
+            format!("postgresql://lattice_test:lattice_test_password@{host}:{port}/{db_name}");
+
+        println!("Connecting to database: {database_url}");
+
+        let pool = PgPool::connect(&database_url)
+            .await
+            .expect("Failed to create pool for database");
+
+        let instance = Self {
+            pool,
+            name: db_name.to_string(),
+            superuser_url: database_url,
+        };
+
+        // Run migrations on this database
+        println!("Running migrations on database: {db_name}");
+        sqlx::migrate!("../../migrations")
+            .run(&instance.pool)
+            .await
+            .expect("Failed to run migrations on database");
+
+        instance
+    }
+
+    /// Drop the isolated database immediately rather than waiting until `TestDb` is dropped.
+    ///
+    /// This is purely an optimisation — cleanup also happens automatically on drop, so
+    /// calling this is never required for test correctness.
+    pub async fn cleanup(&self) {
+        if let Some(sender) = CLEANUP_SENDER.get() {
+            let _ = sender.send(self.name.clone());
+        }
+    }
+
+    /// Begin a transaction against the test database.
+    ///
+    /// The transaction rolls back automatically when dropped, which can be useful for
+    /// low-level repository tests that want to inspect intermediate state without
+    /// committing. Service-level tests should use [`TestContext`] instead, which relies
+    /// on per-test database isolation rather than rollback.
+    pub async fn begin_test_transaction(&self) -> Transaction<'_, Postgres> {
+        self.pool
+            .begin()
+            .await
+            .expect("Failed to start test transaction")
+    }
+
+    /// Returns the connection pool for this test database.
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_database_name_success() {
+        assert!(validate_database_name("valid_name").is_ok());
+        assert!(validate_database_name("_underscore_start").is_ok());
+        assert!(validate_database_name("test123").is_ok());
+        assert!(validate_database_name("my_test_db").is_ok());
+        assert!(validate_database_name("db$with$dollar").is_ok());
+    }
+
+    #[test]
+    fn test_validate_database_name_empty() {
+        assert!(validate_database_name("").is_err());
+    }
+
+    #[test]
+    fn test_validate_database_name_too_long() {
+        let long_name = "a".repeat(64);
+        assert!(validate_database_name(&long_name).is_err());
+    }
+
+    #[test]
+    fn test_validate_database_name_invalid_start() {
+        assert!(validate_database_name("123invalid").is_err());
+        assert!(validate_database_name("-invalid").is_err());
+        assert!(validate_database_name("$invalid").is_err());
+    }
+
+    #[test]
+    fn test_validate_database_name_invalid_characters() {
+        assert!(validate_database_name("invalid-hyphen").is_err());
+        assert!(validate_database_name("invalid.dot").is_err());
+        assert!(validate_database_name("invalid space").is_err());
+        assert!(validate_database_name("invalid@symbol").is_err());
+    }
+
+    #[test]
+    fn test_validate_database_name_reserved_words() {
+        assert!(validate_database_name("user").is_err());
+        assert!(validate_database_name("USER").is_err());
+        assert!(validate_database_name("table").is_err());
+        assert!(validate_database_name("select").is_err());
+        assert!(validate_database_name("database").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_container_startup() {
+        let test_db = TestDb::new().await;
+
+        // Verify we can connect and run a simple query
+        let result: i32 = sqlx::query_scalar("SELECT 1")
+            .fetch_one(test_db.pool())
+            .await
+            .expect("Failed to execute test query");
+
+        assert_eq!(result, 1);
+    }
+
+    #[tokio::test]
+    async fn test_transaction_isolation() {
+        let test_db = TestDb::new().await;
+
+        // Create test table in transaction 1
+        let mut tx1 = test_db.begin_test_transaction().await;
+
+        sqlx::query("CREATE TABLE test_isolation (id INTEGER)")
+            .execute(&mut *tx1)
+            .await
+            .expect("Failed to create table in tx1");
+
+        // Transaction 2 should not see the table
+        let mut tx2 = test_db.begin_test_transaction().await;
+
+        let result = sqlx::query("SELECT COUNT(*) FROM test_isolation")
+            .fetch_one(&mut *tx2)
+            .await;
+
+        // Should fail because table doesn't exist in tx2
+        assert!(result.is_err());
+
+        // Both transactions roll back automatically when dropped
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_method_execution() {
+        let test_db = TestDb::new().await;
+
+        // Verify the database exists and is functional
+        let result: i32 = sqlx::query_scalar("SELECT 1")
+            .fetch_one(test_db.pool())
+            .await
+            .expect("Failed to execute test query");
+        assert_eq!(result, 1);
+
+        test_db.cleanup().await;
+    }
+}

--- a/crates/app/src/test/mod.rs
+++ b/crates/app/src/test/mod.rs
@@ -1,0 +1,6 @@
+//! Test Utilities
+
+mod context;
+mod db;
+
+pub use context::TestContext;


### PR DESCRIPTION
`TestDb` / `TestContext` to run service integration tests with per-test databases and a shared container, including RLS coverage. 

Fixes cart amount decoding to use the actual requested column, return subtotal/total from cart queries, and add missing soft-delete SQL.